### PR TITLE
📖 Adding Google Tag Manager doc links

### DIFF
--- a/extensions/amp-analytics/integrating-analytics.md
+++ b/extensions/amp-analytics/integrating-analytics.md
@@ -52,6 +52,8 @@ The endpoint approach is the same as the standard approach detailed in the previ
 
 To take this approach, review the documentation for publishers' integration with AMP Analytics.
 
+Google Tag Manager has [support](https://developers.google.com/google-ads/amp/landing-pages#google_tag_manager) for AMP pages, and a list of supported tags can be found [here](https://support.google.com/tagmanager/answer/6106924).
+
 ## Add Batch Plugin
 Batch plugin provides an easy way to construct batched requests on client side. Follow the instructions below to add a batch plugin.
 1. Create an [Intent-To-Implement issue](../../CONTRIBUTING.md#contributing-features) stating that you'll be adding the batch plugin to your analytics service AMP HTML's runtime.


### PR DESCRIPTION
More justification in issue 17435. Basically, make it easier for someone to discover GTM's integration with AMP. Completely open to edits, this is just to get a conversation rolling about what it might look like. Not sure if this is the right place to put it.